### PR TITLE
Fix config for Google API key

### DIFF
--- a/backend/Sentiment_logic.py
+++ b/backend/Sentiment_logic.py
@@ -1,5 +1,7 @@
 from langchain_google_genai import ChatGoogleGenerativeAI
 from langchain.prompts import PromptTemplate
+from dotenv import load_dotenv
+import os
 
 # 1. JSON Schema for structured output
 json_schema = {
@@ -31,10 +33,17 @@ json_schema = {
     "required": ["sentiment", "attrition_risk", "issues_detected", "engagement_recommendations"]
 }
 
+# Load environment variables so GOOGLE_API_KEY is available when this module is imported
+load_dotenv()
+
+GOOGLE_API_KEY = os.getenv("GOOGLE_API_KEY")
+if not GOOGLE_API_KEY:
+    raise EnvironmentError("GOOGLE_API_KEY environment variable is not set")
+
 # 2. Configure Gemini model
 llm = ChatGoogleGenerativeAI(
     model="gemini-1.5-flash",
-    google_api_key="AIzaSyA-LbjWvNKnVcvYeWaHaFP0TE8LWRRjwMU",  # Replace with env var in prod
+    google_api_key=GOOGLE_API_KEY,
     temperature=0.3
 )
 

--- a/backend/requirements.txt
+++ b/backend/requirements.txt
@@ -1,7 +1,7 @@
 fastapi==0.104.1
 uvicorn[standard]==0.24.0
 python-multipart==0.0.6
-pydantic==2.4.2
+pydantic<2
 python-dotenv==1.0.0
 langchain>=0.1.16
 langchain-google-genai>=0.0.11

--- a/backend/screening_logic.py
+++ b/backend/screening_logic.py
@@ -1,6 +1,7 @@
 from langchain_community.document_loaders import PyPDFLoader, TextLoader
 from langchain_google_genai import ChatGoogleGenerativeAI
 from langchain.prompts import PromptTemplate
+from dotenv import load_dotenv
 import os
 from typing import Dict, Any
 
@@ -45,10 +46,16 @@ def process_resume(resume_path: str, job_description: str) -> Dict[str, Any]:
             "required": ["match_score", "highlighted_skills", "recommendations"]
         }
 
+        # Load environment variables so GOOGLE_API_KEY is available
+        load_dotenv()
+        google_api_key = os.getenv("GOOGLE_API_KEY")
+        if not google_api_key:
+            raise EnvironmentError("GOOGLE_API_KEY environment variable is not set")
+
         # 3. Configure Gemini model
         llm = ChatGoogleGenerativeAI(
             model="gemini-1.5-flash",
-            google_api_key="AIzaSyA-LbjWvNKnVcvYeWaHaFP0TE8LWRRjwMU",  # Using the same key as Sentiment_logic.py
+            google_api_key=google_api_key,
             temperature=0.1
         )
 


### PR DESCRIPTION
## Summary
- load environment variables in sentiment & screening modules
- pull Google API key from the environment
- pin pydantic to pre-v2 to avoid runtime issues

## Testing
- `python -m py_compile backend/*.py`

------
https://chatgpt.com/codex/tasks/task_e_68440fedbf78832383a1c199a449a15f